### PR TITLE
bump rust crates versions for v24.08.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cln-grpc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "cln-grpc-plugin"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "cln-grpc",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "cln-plugin"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "cln-rpc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bitcoin",

--- a/cln-grpc/Cargo.toml
+++ b/cln-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-grpc"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "The Core Lightning API as grpc primitives. Provides the bindings used to expose the API over the network."

--- a/cln-rpc/Cargo.toml
+++ b/cln-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-rpc"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "An async RPC client for Core Lightning."

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cln-plugin"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "A CLN plugin library. Write your plugin in Rust."

--- a/plugins/grpc-plugin/Cargo.toml
+++ b/plugins/grpc-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "cln-grpc-plugin"
-version = "0.2.0"
+version = "0.2.1"
 
 description = "A Core Lightning plugin that re-exposes the JSON-RPC over grpc. Authentication is done via mTLS."
 license = "MIT"


### PR DESCRIPTION
Since there were changes made in 24.08.2 in the crates we should bump these versions so the CI will release them to crates.io